### PR TITLE
Feature: Add a new `wrap` function to wrap `textarea` elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A beautiful, modern, customizable Markdown editor powered by CodeMirror 6 and Ty
 - [x] Vue wrapper (`ink-mde/vue` subpath export)
 - [x] Svelte wrapper (`ink-mde/svelte` subpath export)
 - [x] Supports Server-Side Rendering (SSR)
+- [x] Wrap a native `textarea` element with the `wrap` export
 - [x] Plugin API (experimental)
 
 ## Getting Started
@@ -64,10 +65,20 @@ Mount the component and start writing.
 
 ```ts
 // ./examples/minimal.ts
-import ink from 'ink-mde'
+import { ink } from 'ink-mde'
 
 // The only requirement is an HTML element.
 ink(document.getElementById('editor')!)
+```
+
+##### Wrap a native `textarea` with `wrap`
+
+To wrap a native `textarea` element, use the `wrap` export.
+
+```ts
+import { wrap } from 'ink-mde'
+
+wrap(document.querySelector('textarea')!)
 ```
 
 #### Track state changes with hooks

--- a/examples/minimal.ts
+++ b/examples/minimal.ts
@@ -1,4 +1,4 @@
-import ink from 'ink-mde'
+import { ink } from 'ink-mde'
 
 // The only requirement is an HTML element.
 ink(document.getElementById('editor')!)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -59,4 +59,21 @@ export const solidPrepareForHydration = () => {
   let e,t;e=window._$HY||(window._$HY={events:[],completed:new WeakSet,r:{}}),t=e=>e&&e.hasAttribute&&(e.hasAttribute("data-hk")?e:t(e.host&&e.host instanceof Node?e.host:e.parentNode)),['click', 'input'].forEach((o=>document.addEventListener(o,(o=>{let s=o.composedPath&&o.composedPath()[0]||o.target,a=t(s);a&&!e.completed.has(a)&&e.events.push([a,o])})))),e.init=(t,o)=>{e.r[t]=[new Promise(((e,t)=>o=e)),o]},e.set=(t,o,s)=>{(s=e.r[t])&&s[1](o),e.r[t]=[o]},e.unset=t=>{delete e.r[t]},e.load=(t,o)=>{if(o=e.r[t])return o[0]}
 }
 
+export const wrap = (textarea: HTMLTextAreaElement, options: Ink.Options = {}) => {
+  const replacement = <div class='ink-mde-textarea' /> as HTMLDivElement
+
+  textarea.after(replacement)
+  textarea.style.display = 'none'
+
+  const instance = render(textarea, options)
+
+  if (textarea.form) {
+    textarea.form.addEventListener('submit', () => {
+      textarea.value = instance.getDoc()
+    })
+  }
+
+  return instance
+}
+
 export default ink

--- a/test/src/__snapshots__/index.test.ts.snap
+++ b/test/src/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ink > matches the snapshot 1`] = `
+exports[`ink > ink > matches the snapshot 1`] = `
 <div>
   <div
     class="ink ink-mde"

--- a/test/src/index.test.ts
+++ b/test/src/index.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockAll } from '/test/helpers/dom'
-import { ink } from '/src/index'
+import { ink, wrap } from '/src/index'
 import example from '/test/assets/example.md?raw'
 
 describe('ink', () => {
@@ -9,44 +9,73 @@ describe('ink', () => {
     mockAll()
   })
 
-  it('mounts without errors', () => {
-    const instance = ink(document.createElement('div'))
+  describe('ink', () => {
+    it('mounts without errors', () => {
+      const instance = ink(document.createElement('div'))
 
-    expect(instance).toBeDefined()
-  })
-
-  it('matches the given options', () => {
-    const instance = ink(document.createElement('div'), {
-      doc: '# Hello',
+      expect(instance).toBeDefined()
     })
 
-    expect(instance.getDoc()).toEqual('# Hello')
-  })
+    it('matches the given options', () => {
+      const instance = ink(document.createElement('div'), {
+        doc: '# Hello',
+      })
 
-  it('can be reconfigured', () => {
-    const instance = ink(document.createElement('div'), {
-      interface: {
-        appearance: 'light',
-      },
+      expect(instance.getDoc()).toEqual('# Hello')
     })
 
-    instance.reconfigure({ interface: { appearance: 'light' } })
+    it('can be reconfigured', () => {
+      const instance = ink(document.createElement('div'), {
+        interface: {
+          appearance: 'light',
+        },
+      })
 
-    expect(instance.options().interface.appearance).toEqual('light')
-  })
+      instance.reconfigure({ interface: { appearance: 'light' } })
 
-  it('matches the snapshot', () => {
-    const target = document.createElement('div')
-
-    // Todo: Use a comprehensive starter doc.
-    ink(target, {
-      doc: example,
-      interface: {
-        images: true,
-        toolbar: true,
-      },
+      expect(instance.options().interface.appearance).toEqual('light')
     })
 
-    expect(target).toMatchSnapshot()
+    it('matches the snapshot', () => {
+      const target = document.createElement('div')
+
+      // Todo: Use a comprehensive starter doc.
+      ink(target, {
+        doc: example,
+        interface: {
+          images: true,
+          toolbar: true,
+        },
+      })
+
+      expect(target).toMatchSnapshot()
+    })
+  })
+
+  describe('wrap', () => {
+    it('injects the editor after the textarea', () => {
+      const form = document.createElement('form')
+      const textarea = document.createElement('textarea')
+
+      form.appendChild(textarea)
+
+      wrap(textarea)
+
+      expect(form.children.length).toEqual(2)
+    })
+
+    it('updates the value of textarea on submit', () => {
+      const form = document.createElement('form')
+      const textarea = document.createElement('textarea')
+
+      form.appendChild(textarea)
+
+      const instance = wrap(textarea)
+
+      instance.insert('testing')
+      form.dispatchEvent(new Event('submit'))
+
+      expect(textarea.value).toEqual('testing')
+    })
   })
 })

--- a/types/ink.d.ts
+++ b/types/ink.d.ts
@@ -26,7 +26,7 @@ export interface Instance {
   focus: () => void
   format: (type: EnumString<InkValues.Markup>, options: Instance.FormatOptions) => void
   getDoc: () => string
-  insert: (text: string, selection: Editor.Selection) => void
+  insert: (text: string, selection?: Editor.Selection) => void
   load: (doc: string) => void
   options: () => OptionsResolved
   reconfigure: (updates: Options) => void


### PR DESCRIPTION
- closes #28 

### Example

```ts
import { wrap } from 'ink-mde'

wrap(document.querySelector('textarea')!)
```